### PR TITLE
Fixed Import Issue

### DIFF
--- a/pyrism/models/models.py
+++ b/pyrism/models/models.py
@@ -7,8 +7,7 @@ from collections import namedtuple
 
 import numpy as np
 from scipy.integrate import (quad, dblquad)
-from scipy.misc import factorial
-from scipy.special import expi
+from scipy.special import factorial, expi
 
 from .library import get_data_one, get_data_two
 from ..core import (Kernel, Scattering, ReflectanceResult, EmissivityResult, SailResult, cot, rad, dB, BRDF, BRF)


### PR DESCRIPTION
The `factorial` module in `scipy` has been moved to `scipy.special` from `scipy.misc`. This commit fixes the import error caused by this change.