### PR TITLE
Update models.py

### DIFF
--- a/pyrism/models/models.py
+++ b/pyrism/models/models.py
@@ -7,8 +7,7 @@ from collections import namedtuple
 
 import numpy as np
 from scipy.integrate import (quad, dblquad)
-from scipy.misc import factorial
-from scipy.special import expi
+from scipy.special import factorial, expi
 
 from .library import get_data_one, get_data_two
 from ..core import (Kernel, Scattering, ReflectanceResult, EmissivityResult, SailResult, cot, rad, dB, BRDF, BRF)


### PR DESCRIPTION
small update:
factorial is deprecated! Importing factorial from scipy.misc is deprecated in scipy 1.0.0. Use scipy.special.factorial instead.